### PR TITLE
fix: atom should unmount correctly

### DIFF
--- a/.changeset/curly-tips-flow.md
+++ b/.changeset/curly-tips-flow.md
@@ -1,0 +1,5 @@
+---
+'rippling': minor
+---
+
+fix: critical bug affect unmount behavior

--- a/packages/rippling/src/core/atom-manager.ts
+++ b/packages/rippling/src/core/atom-manager.ts
@@ -92,9 +92,10 @@ export class AtomManager {
       if (atomState.dependencies === readDeps) {
         readDeps.set(depAtom, depState.epoch);
 
-        if (atomState.mounted && !depState.mounted) {
+        const selfMounted = !!atomState.mounted;
+        if (selfMounted && !depState.mounted) {
           this.mount(depAtom).readDepts.add(self);
-        } else if (depState.mounted) {
+        } else if (selfMounted && depState.mounted) {
           depState.mounted.readDepts.add(self);
         }
       }


### PR DESCRIPTION
- Issue:

```
const base$ = $value(0);
const derived1$ = $computed((get) => get(base$));
const derived2$ = $computed((get) => get(base$));

const unsub = store.sub(derived1$, ...)
store.get(derived2$)
unsub()
```

In the code above, even after executing unsub, the store still considers base$ to be in a mounted state.

- Expected behavior:

Reading `derived2$` should not affect the mount state of `base$`.

- Root cause:

AtomManager does not check if the dependent atom is in a mounted state when maintaining dependencies for base$.

- Fix:

Only Computed atoms that are themselves in a mounted state should be able to add dependencies to the atoms they read from.
