### PR TITLE
fix: critical bug in dynamic deps track

### DIFF
--- a/.changeset/heavy-geckos-obey.md
+++ b/.changeset/heavy-geckos-obey.md
@@ -1,0 +1,5 @@
+---
+'rippling': minor
+---
+
+fix: critical bug in dynamic deps track

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Use `$value` to create a simple value unit, and use `$computed` to create a deri
 
 ```ts
 // atom.js
-import { $value, $computed } from 'rippling/core';
+import { $value, $computed } from 'rippling';
 
 export const userId$ = $value('');
 
@@ -58,7 +58,7 @@ Use `useGet` and `useSet` hooks in React to get/set atoms, and use `useResolved`
 
 ```jsx
 // App.js
-import { useGet, useSet, useResolved } from 'rippling/react';
+import { useGet, useSet, useResolved } from 'rippling';
 import { userId$, user$ } from './atom';
 
 export default function App() {
@@ -87,8 +87,7 @@ Use `createStore` and `StoreProvider` to provide a Rippling store to React, all 
 
 ```tsx
 // main.jsx
-import { createStore } from 'rippling/core';
-import { StoreProvider } from 'rippling/react';
+import { createStore, StoreProvider } from 'rippling';
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "lint:eslint": "eslint .",
     "lint:format": "prettier '**/*' --ignore-unknown --list-different",
     "ci:version": "changeset version && pnpm lint-staged",
-    "ci:publish": "pnpm publish:lib; pnpm publish:babel",
+    "ci:publish": "pnpm publish:lib; pnpm publish:babel; echo 0",
     "publish:lib": "cd packages/rippling/dist && pnpm publish",
     "publish:babel": "cd packages/babel/dist && pnpm publish",
     "prepare": "husky"

--- a/packages/rippling/src/core/__tests__/store.test.ts
+++ b/packages/rippling/src/core/__tests__/store.test.ts
@@ -680,3 +680,36 @@ it('should unmount base$ atom in this complex scenario', () => {
 
   expect(nestedAtomToString(store.getReadDependents(base$))).toEqual(['base$']);
 });
+
+it('shoule unmount base$ atom in this complex scenario 2', () => {
+  const base1$ = $value(0, {
+    debugLabel: 'base1$',
+  });
+  const base2$ = $value(0, {
+    debugLabel: 'base2$',
+  });
+  const branch$ = $value(true, {
+    debugLabel: 'branch$',
+  });
+  const derived$ = $computed(
+    (get) => {
+      if (get(branch$)) {
+        return get(base1$);
+      }
+      return get(base2$);
+    },
+    {
+      debugLabel: 'derived$',
+    },
+  );
+
+  const store = createDebugStore();
+  const unsub = store.sub(
+    derived$,
+    $func(() => void 0),
+  );
+  store.set(branch$, false);
+  unsub();
+
+  expect(nestedAtomToString(store.getReadDependents(base2$))).toEqual(['base2$']);
+});

--- a/packages/rippling/src/debug/debug-store.ts
+++ b/packages/rippling/src/debug/debug-store.ts
@@ -3,7 +3,6 @@ import type { DebugStore } from '../../types/debug/debug-store';
 import type { NestedAtom } from '../../types/debug/util';
 import type { Computed, Func, Subscribe, Value } from '../core';
 import { AtomManager, ListenerManager } from '../core/atom-manager';
-import type { ComputedState } from '../core/atom-manager';
 import { StoreImpl } from '../core/store';
 
 class DebugStoreImpl extends StoreImpl implements DebugStore {
@@ -50,7 +49,7 @@ class DebugStoreImpl extends StoreImpl implements DebugStore {
 
     return [
       atom,
-      ...Array.from((atomState as ComputedState<unknown>).dependencies).map(([key]) => {
+      ...Array.from(atomState.dependencies).map(([key]) => {
         return this.getReadDependencies(key);
       }),
     ] as NestedAtom;


### PR DESCRIPTION
# Case
```
const base1$ = $value(0);
const base2$ = $value(0);
const branch$ = $value(true);
const derived$ = $computed(
  (get) => {
    if (get(branch$)) {
      return get(base1$);
    }
    return get(base2$);
  }
);

const store = createDebugStore();
const unsub = store.sub(
  derived$,
  $func(() => void 0),
);
store.set(branch$, false);
unsub();
```
## Expected Behavior

`base2$` should be unmounted.

## Actual Behavior
`base2$` still remains mounted after `derived$` is unsubscribed.

## Why
`mountState` has an independent map for tracking dependencies. This map is not updated correctly when Computed dependencies are changed.

## Hot to fix

Removed the redundancy map in `mountState`, and use dependencies in `atomState`.