### PR TITLE
fix: unmount bug

### DIFF
--- a/.changeset/eleven-swans-float.md
+++ b/.changeset/eleven-swans-float.md
@@ -1,0 +1,5 @@
+---
+'rippling': minor
+---
+
+fix: crtical unmount bug

--- a/packages/rippling/src/core/__tests__/store.test.ts
+++ b/packages/rippling/src/core/__tests__/store.test.ts
@@ -713,3 +713,50 @@ it('shoule unmount base$ atom in this complex scenario 2', () => {
 
   expect(nestedAtomToString(store.getReadDependents(base2$))).toEqual(['base2$']);
 });
+
+it('shoule unmount base$ atom in this complex scenario 3', () => {
+  const base$ = $value(0);
+  const branch$ = $value(true);
+  const derived$ = $computed((get) => {
+    if (!get(branch$)) {
+      return;
+    }
+    return get(base$);
+  });
+
+  const store = createDebugStore();
+  store.sub(
+    derived$,
+    $func(() => void 0),
+  );
+  expect(store.isMounted(base$)).toBeTruthy();
+
+  store.set(branch$, false);
+
+  expect(store.isMounted(base$)).toBeFalsy();
+});
+
+it('shoule unmount base$ atom in this complex scenario 4', () => {
+  const base$ = $value(0);
+  const branch$ = $value(true);
+  const derived$ = $computed((get) => {
+    if (!get(branch$)) {
+      return;
+    }
+    return get(base$);
+  });
+
+  const store = createDebugStore();
+  store.sub(
+    derived$,
+    $func(() => void 0),
+  );
+  store.sub(
+    base$,
+    $func(() => void 0),
+  );
+
+  store.set(branch$, false);
+
+  expect(store.isMounted(base$)).toBeTruthy();
+});

--- a/packages/rippling/src/core/store.ts
+++ b/packages/rippling/src/core/store.ts
@@ -139,7 +139,7 @@ export class StoreImpl implements Store {
           mounted.listeners.delete(cb$);
 
           if (mounted.readDepts.size === 0 && mounted.listeners.size === 0) {
-            this.atomManager.unmount(target$);
+            this.atomManager.tryUnmount(target$);
           }
 
           options?.signal?.addEventListener('abort', fn);

--- a/packages/rippling/src/debug/debug-store.ts
+++ b/packages/rippling/src/debug/debug-store.ts
@@ -72,6 +72,11 @@ class DebugStoreImpl extends StoreImpl implements DebugStore {
       return [atom, ...listeners];
     });
   };
+
+  isMounted = (atom: Value<unknown> | Computed<unknown>): boolean => {
+    const mountState = this.atomManager.readAtomState(atom);
+    return mountState.mounted !== undefined;
+  };
 }
 
 export function createDebugStore(interceptor?: StoreInterceptor): DebugStore {

--- a/packages/rippling/types/debug/debug-store.ts
+++ b/packages/rippling/types/debug/debug-store.ts
@@ -5,5 +5,6 @@ import type { NestedAtom } from './util';
 export interface DebugStore extends Store {
   getReadDependencies: (atom: Computed<unknown>) => NestedAtom;
   getReadDependents: (atom: Value<unknown> | Computed<unknown>) => NestedAtom;
+  isMounted: (atom: Value<unknown> | Computed<unknown>) => boolean;
   getSubscribeGraph: () => NestedAtom;
 }


### PR DESCRIPTION
# Case
```
const base$ = $value(0);
const branch$ = $value(true);
const derived$ = $computed((get) => {
  if (!get(branch$)) {
    return;
  }
  return get(base$);
});

const store = createDebugStore();
store.sub(
  derived$,
  $func(() => void 0),
);
store.set(branch$, false);
```
## Expected Behavior

`base$` should be unmounted.

## Actual Behavior
`base$` remains mounted.

## Why

Dynamic tracking correctly updated the dependencies set but did not remove mountState after that set had already been empty.

## Hot to fix

After dynamic tracking update dependencies, remove empty mountState.