### PR TITLE
chore: bump all packages to 5.2.3

### DIFF
--- a/packages/babel/package.json
+++ b/packages/babel/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccstate-babel",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "CCState Babel Plugin",
   "private": true,
   "repository": {

--- a/packages/ccstate/package.json
+++ b/packages/ccstate/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccstate",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "CCState Core",
   "private": true,
   "repository": {

--- a/packages/solid/package.json
+++ b/packages/solid/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccstate-solid",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "CCState Solid.js Hooks",
   "repository": {
     "type": "git",

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccstate-svelte",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "CCState Svelte Hooks",
   "repository": {
     "type": "git",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ccstate-vue",
-  "version": "5.2.2",
+  "version": "5.2.3",
   "description": "CCState Vue Hooks",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Bump ccstate, babel, solid, svelte, vue packages from 5.2.3 to 5.2.3
- react was already at 5.2.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)