### PR TITLE
chore: remove stale changeset

### DIFF
--- a/.changeset/react-useget-signal-ref.md
+++ b/.changeset/react-useget-signal-ref.md
@@ -1,5 +1,0 @@
----
-'ccstate-react': patch
----
-
-Fix `useGet` subscriptions when the atom argument changes.


### PR DESCRIPTION
## Summary
- remove the stale useGet changeset left on main after the 5.2.4 version bump landed
- keep the existing 5.2.4 package versions intact so the next main Changesets run can publish them

## Checks
- pnpm lint
- pnpm test
- CI-equivalent pnpm 9 frozen install was validated before this cleanup