### PR TITLE
ci: pass npm token to publish step

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -46,3 +46,5 @@ jobs:
       - name: Publish to npm
         if: steps.changesets.outputs.hasChangesets == 'false'
         run: pnpm ci:publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- pass the existing NPM_TOKEN secret as NODE_AUTH_TOKEN during the npm publish step
- fixes the main Changesets workflow failing at publish despite reaching pnpm ci:publish

## Checks
- pnpm lint
- pnpm test