### PR TITLE
ci: use npm for oidc publishing

### DIFF
--- a/.github/workflows/changeset.yaml
+++ b/.github/workflows/changeset.yaml
@@ -26,8 +26,13 @@ jobs:
             - args: [--frozen-lockfile, --strict-peer-dependencies]
       - uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org'
+      - name: Use npm 11 for trusted publishing
+        run: |
+          npm install -g npm@^11.5.1
+          node --version
+          npm --version
       - name: build
         run: pnpm build
       - name: lint

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "ci:publish": "pnpm '/^publish:.*/'",
     "publish:core": "cd packages/ccstate/dist && npm publish",
     "publish:babel": "cd packages/babel/dist && npm publish",
-    "publish:react": "pnpm -F ccstate-react publish --no-git-checks",
-    "publish:vue": "pnpm -F ccstate-vue publish --no-git-checks",
-    "publish:solid": "pnpm -F ccstate-solid publish --no-git-checks",
-    "publish:svelte": "pnpm -F ccstate-svelte publish --no-git-checks",
+    "publish:react": "cd packages/react && npm publish",
+    "publish:vue": "cd packages/vue && npm publish",
+    "publish:solid": "cd packages/solid && npm publish",
+    "publish:svelte": "cd packages/svelte && npm publish",
     "prepare": "husky"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- run the Changesets publish workflow on Node 24 and install npm >=11.5.1 for npm trusted publishing
- publish all packages with npm CLI instead of mixing npm and pnpm publish
- keep publish auth token-free so npm can use GitHub Actions OIDC/trusted publishing

## Checks
- corepack pnpm@9.15.9 install --frozen-lockfile --strict-peer-dependencies
- pnpm build
- pnpm lint
- pnpm test
- npm pack --dry-run in packages/react, packages/solid, packages/svelte, packages/vue