### PR TITLE
fix: publish adapters with pnpm pack

### DIFF
--- a/.changeset/fair-masks-share.md
+++ b/.changeset/fair-masks-share.md
@@ -1,0 +1,8 @@
+---
+'ccstate-react': patch
+'ccstate-vue': patch
+'ccstate-solid': patch
+'ccstate-svelte': patch
+---
+
+republish adapter packages with npm-compatible ccstate dependencies

--- a/package.json
+++ b/package.json
@@ -29,10 +29,10 @@
     "ci:publish": "npm run publish:core && npm run publish:babel && npm run publish:react && npm run publish:vue && npm run publish:solid && npm run publish:svelte",
     "publish:core": "cd packages/ccstate/dist && npm publish",
     "publish:babel": "cd packages/babel/dist && npm publish",
-    "publish:react": "cd packages/react && npm publish",
-    "publish:vue": "cd packages/vue && npm publish",
-    "publish:solid": "cd packages/solid && npm publish",
-    "publish:svelte": "cd packages/svelte && npm publish",
+    "publish:react": "node scripts/pnpm-pack-and-npm-publish.mjs ccstate-react",
+    "publish:vue": "node scripts/pnpm-pack-and-npm-publish.mjs ccstate-vue",
+    "publish:solid": "node scripts/pnpm-pack-and-npm-publish.mjs ccstate-solid",
+    "publish:svelte": "node scripts/pnpm-pack-and-npm-publish.mjs ccstate-svelte",
     "prepare": "husky"
   },
   "engines": {

--- a/scripts/pnpm-pack-and-npm-publish.mjs
+++ b/scripts/pnpm-pack-and-npm-publish.mjs
@@ -1,0 +1,36 @@
+import { mkdtempSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+
+const [filter, ...publishArgs] = process.argv.slice(2);
+
+if (!filter) {
+  console.error('Usage: node scripts/pnpm-pack-and-npm-publish.mjs <pnpm-filter> [npm-publish-args...]');
+  process.exit(1);
+}
+
+function run(command, args) {
+  const result = spawnSync(command, args, { stdio: 'inherit' });
+
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
+}
+
+const packDir = mkdtempSync(join(tmpdir(), 'ccstate-pack-'));
+
+try {
+  run('pnpm', ['--filter', filter, 'pack', '--pack-destination', packDir]);
+
+  const tarballs = readdirSync(packDir).filter((file) => file.endsWith('.tgz'));
+
+  if (tarballs.length !== 1) {
+    console.error(`Expected one tarball in ${packDir}, found ${tarballs.length}.`);
+    process.exit(1);
+  }
+
+  run('npm', ['publish', join(packDir, tarballs[0]), ...publishArgs]);
+} finally {
+  rmSync(packDir, { recursive: true, force: true });
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -5,7 +5,14 @@ export default defineConfig({
     coverage: {
       reporter: ['text', 'json-summary', 'json', 'cobertura', 'html'],
       provider: 'v8',
-      exclude: [...coverageConfigDefaults.exclude, '**/dist/**', '**/types/**', '**/*.config.*', '**/coverage/**'],
+      exclude: [
+        ...coverageConfigDefaults.exclude,
+        '**/dist/**',
+        '**/types/**',
+        '**/*.config.*',
+        '**/coverage/**',
+        'scripts/pnpm-pack-and-npm-publish.mjs',
+      ],
     },
   },
 });


### PR DESCRIPTION
## Summary
- Pack adapter packages with pnpm so workspace protocol dependencies are rewritten before publishing.
- Publish the generated tarballs with npm to keep trusted publishing/OIDC semantics.
- Add a changeset to republish adapter packages with npm-compatible ccstate dependencies.

## Verification
- npm run publish:react -- --dry-run
- pnpm --filter ccstate-react --filter ccstate-vue --filter ccstate-solid --filter ccstate-svelte pack --pack-destination /tmp/ccstate-pack-check
- verified each packed adapter package.json has dependencies.ccstate as ^5.2.4
- pre-commit: pnpm lint and pnpm test