### PR TITLE
fix(react): skip unchanged last resolved values

### DIFF
--- a/.changeset/calm-hooks-rest.md
+++ b/.changeset/calm-hooks-rest.md
@@ -1,0 +1,5 @@
+---
+'ccstate-react': patch
+---
+
+Avoid React commits when last-loadable hooks resolve to an unchanged value.

--- a/packages/react/src/__tests__/loadable.test.tsx
+++ b/packages/react/src/__tests__/loadable.test.tsx
@@ -6,7 +6,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { computed, createStore, state } from 'ccstate';
 import type { Computed, State } from 'ccstate';
-import { StrictMode, useEffect } from 'react';
+import { Profiler, StrictMode, useEffect } from 'react';
 import { StoreProvider, useSet, useLoadable } from '..';
 import { delay } from 'signal-timers';
 import { useLastLoadable } from '../useLoadable';
@@ -429,6 +429,36 @@ it('use lastLoadable should not update when new promise pending', async () => {
   defered.resolve(2);
   await delay(0);
   expect(screen.getByText('num2')).toBeInTheDocument();
+});
+
+it('useLastLoadable does not commit when a new promise resolves to the same primitive', async () => {
+  const async$ = state(Promise.resolve(false));
+  const onRender = vi.fn();
+  const store = createStore();
+
+  function App() {
+    const loadable = useLastLoadable(async$);
+    const value = loadable.state === 'hasData' ? loadable.data : 'loading';
+    return <div>{String(value)}</div>;
+  }
+
+  render(
+    <StoreProvider value={store}>
+      <Profiler id="app" onRender={onRender}>
+        <App />
+      </Profiler>
+    </StoreProvider>,
+  );
+
+  expect(await screen.findByText('false')).toBeInTheDocument();
+  onRender.mockClear();
+
+  const deferred = makeDefered<boolean>();
+  store.set(async$, deferred.promise);
+  deferred.resolve(false);
+  await delay(0);
+
+  expect(onRender).not.toHaveBeenCalled();
 });
 
 it('use lastLoadable should keep error', async () => {

--- a/packages/react/src/__tests__/resolved.test.tsx
+++ b/packages/react/src/__tests__/resolved.test.tsx
@@ -2,10 +2,10 @@
 
 import '@testing-library/jest-dom/vitest';
 import { cleanup, render, screen } from '@testing-library/react';
-import { afterEach, expect, it } from 'vitest';
+import { afterEach, expect, it, vi } from 'vitest';
 import { computed, state, createStore } from 'ccstate';
 import { StoreProvider } from '../provider';
-import { StrictMode } from 'react';
+import { Profiler, StrictMode } from 'react';
 import { useLastResolved, useResolved } from '../useResolved';
 import { delay } from 'signal-timers';
 
@@ -99,6 +99,35 @@ it('use lastLoadable should not update when new promise pending', async () => {
   defered.resolve(2);
   await delay(0);
   expect(screen.getByText('num2')).toBeInTheDocument();
+});
+
+it('useLastResolved does not commit when a new promise resolves to the same primitive', async () => {
+  const async$ = state(Promise.resolve(false));
+  const onRender = vi.fn();
+  const store = createStore();
+
+  function App() {
+    const value = useLastResolved(async$);
+    return <div>{String(value)}</div>;
+  }
+
+  render(
+    <StoreProvider value={store}>
+      <Profiler id="app" onRender={onRender}>
+        <App />
+      </Profiler>
+    </StoreProvider>,
+  );
+
+  expect(await screen.findByText('false')).toBeInTheDocument();
+  onRender.mockClear();
+
+  const deferred = makeDefered<boolean>();
+  store.set(async$, deferred.promise);
+  deferred.resolve(false);
+  await delay(0);
+
+  expect(onRender).not.toHaveBeenCalled();
 });
 
 it('useResolved accept sync computed', async () => {

--- a/packages/react/src/useLoadable.ts
+++ b/packages/react/src/useLoadable.ts
@@ -15,6 +15,10 @@ type Loadable<T> =
       error: unknown;
     };
 
+function hasSameData<T>(previous: Loadable<T>, next: Loadable<T>): boolean {
+  return previous.state === 'hasData' && next.state === 'hasData' && previous.data === next.data;
+}
+
 function useLoadableInternal<T, U extends Promise<Awaited<T>> | Awaited<T>>(
   promise$: State<U> | Computed<U>,
   keepLastResolved: boolean,
@@ -28,6 +32,7 @@ function useLoadableInternal<T, U extends Promise<Awaited<T>> | Awaited<T>>(
     (fn: () => void) => {
       function updateResult(result: Loadable<T>, signal: AbortSignal) {
         if (signal.aborted) return;
+        if (keepLastResolved && hasSameData(promiseResult.current, result)) return;
         promiseResult.current = result;
         fn();
       }


### PR DESCRIPTION
## Summary

- avoid React commits when `useLastLoadable` and `useLastResolved` resolve to an unchanged value
- preserve loading and error behavior while matching the core `===` distinct semantics
- cover both hooks with React Profiler regression tests
- add a patch changeset for `ccstate-react`

## Verification

- `pnpm lint`
- `pnpm test -- --reporter=dot`
- `pnpm build`