### PR TITLE
feat(react): add equality and loadable state hooks

### DIFF
--- a/.changeset/bright-hooks-compare.md
+++ b/.changeset/bright-hooks-compare.md
@@ -1,0 +1,5 @@
+---
+'ccstate-react': minor
+---
+
+Add custom equality functions for React value hooks and primitive loadable-state hooks.

--- a/docs/react.md
+++ b/docs/react.md
@@ -46,6 +46,16 @@ function App() {
 
 `useGet` returns a `State` or a `Computed` value, and when the value changes, `useGet` triggers a re-render of the component.
 
+By default, `useGet` compares snapshots with `Object.is`. Pass an `equalityFn` when a computed value can return a new reference that is equivalent for rendering:
+
+```jsx
+const user = useGet(user$, {
+  equalityFn: (previous, next) => previous.id === next.id && previous.name === next.name,
+});
+```
+
+When `equalityFn` returns `true`, `useGet` keeps the previous snapshot reference and skips the React commit. Prefer stable computed values or primitive projections when possible, and use a custom equality function only where the comparison is cheaper than rendering.
+
 `useGet` does not do anything special with `Promise` values. In fact, `useGet` is equivalent to a single `store.get` call, plus a `store.watch` to ensure reactive updates to the React component.
 
 Two other useful hooks are available when dealing with `Promise` values. First, we introduce `useLoadable`.
@@ -89,6 +99,17 @@ type Loadable<T> =
 ```
 
 This allows you to render loading and error states in JSX based on the state. `useLoadable` suppresses exceptions, so it will not trigger an `ErrorBoundary`.
+
+If a component only needs the loadable state, use `useLoadableState`. It returns the primitive union `'loading' | 'hasData' | 'hasError'` and does not commit when only the resolved data or error reference changes without a state transition.
+
+```jsx
+import { useLoadableState } from 'ccstate-react';
+
+function LoadingIndicator() {
+  const state = useLoadableState(user$);
+  return state === 'loading' ? <div>Loading...</div> : null;
+}
+```
 
 Another useful hook is `useResolved`, which always returns the resolved value of a `Promise`.
 
@@ -154,6 +175,10 @@ function App() {
 ```
 
 `useLastResolved` behaves similarly - it always returns the last resolved value from a Promise Atom and won't reset to `undefined` when a new Promise is generated.
+
+`useLastLoadableState` is the state-only counterpart to `useLastLoadable`. After the first value resolves, it keeps returning `'hasData'` while a replacement Promise is pending and does not commit when that Promise resolves to new data.
+
+`useLastResolved` and `useLastLoadable` also accept an optional `equalityFn`. Equal resolved values preserve the previous reference and do not trigger a React commit.
 
 ## Updating State / Triggering Command
 

--- a/docs/react.md
+++ b/docs/react.md
@@ -176,8 +176,6 @@ function App() {
 
 `useLastResolved` behaves similarly - it always returns the last resolved value from a Promise Atom and won't reset to `undefined` when a new Promise is generated.
 
-`useLastLoadableState` is the state-only counterpart to `useLastLoadable`. After the first value resolves, it keeps returning `'hasData'` while a replacement Promise is pending and does not commit when that Promise resolves to new data.
-
 `useLastResolved` and `useLastLoadable` also accept an optional `equalityFn`. Equal resolved values preserve the previous reference and do not trigger a React commit.
 
 ## Updating State / Triggering Command

--- a/packages/react/src/__tests__/get-and-set.test.tsx
+++ b/packages/react/src/__tests__/get-and-set.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { computed, createStore, command, state, createDebugStore } from 'ccstate';
 import { StoreProvider, useGet, useSet } from '..';
-import { StrictMode, useState } from 'react';
+import { Profiler, StrictMode, useState } from 'react';
 import '@testing-library/jest-dom/vitest';
 
 describe('react', () => {
@@ -71,6 +71,39 @@ describe('react', () => {
     store.set(base, 1);
     await Promise.resolve();
     expect(trace).not.toBeCalled();
+  });
+
+  it('useGet skips commits when equalityFn considers a new value equal', async () => {
+    const store = createStore();
+    const value$ = state({ count: 1 });
+    const onRender = vi.fn();
+
+    function App() {
+      const value = useGet(value$, {
+        equalityFn: (previous, next) => previous.count === next.count,
+      });
+      return <div>{value.count}</div>;
+    }
+
+    render(
+      <StoreProvider value={store}>
+        <Profiler id="app" onRender={onRender}>
+          <App />
+        </Profiler>
+      </StoreProvider>,
+    );
+
+    expect(screen.getByText('1')).toBeInTheDocument();
+    onRender.mockClear();
+
+    store.set(value$, { count: 1 });
+    await Promise.resolve();
+    expect(onRender).not.toHaveBeenCalled();
+
+    store.set(value$, { count: 2 });
+    await Promise.resolve();
+    expect(onRender).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('2')).toBeInTheDocument();
   });
 
   it('user click counter should increment', async () => {

--- a/packages/react/src/__tests__/loadable.test.tsx
+++ b/packages/react/src/__tests__/loadable.test.tsx
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { computed, createStore, state } from 'ccstate';
 import type { Computed, State } from 'ccstate';
 import { Profiler, StrictMode, useEffect } from 'react';
-import { StoreProvider, useSet, useLoadable, useLoadableState, useLastLoadableState } from '..';
+import { StoreProvider, useSet, useLoadable, useLoadableState } from '..';
 import { delay } from 'signal-timers';
 import { useLastLoadable } from '../useLoadable';
 
@@ -61,34 +61,46 @@ it('convert promise to loadable', async () => {
 
 it('useLoadableState only commits when the loadable state changes', async () => {
   const value$ = state({ count: 1 });
-  const onRender = vi.fn();
+  const onLoadableRender = vi.fn();
+  const onStateRender = vi.fn();
   const store = createStore();
 
-  function App() {
+  function Loadable() {
+    const loadable = useLoadable(value$);
+    return <div>{loadable.state}</div>;
+  }
+
+  function LoadableState() {
     const loadableState = useLoadableState(value$);
     return <div>{loadableState}</div>;
   }
 
   render(
     <StoreProvider value={store}>
-      <Profiler id="app" onRender={onRender}>
-        <App />
+      <Profiler id="loadable" onRender={onLoadableRender}>
+        <Loadable />
+      </Profiler>
+      <Profiler id="state" onRender={onStateRender}>
+        <LoadableState />
       </Profiler>
     </StoreProvider>,
   );
 
-  expect(await screen.findByText('hasData')).toBeInTheDocument();
-  onRender.mockClear();
+  expect(screen.getAllByText('hasData')).toHaveLength(2);
+  onLoadableRender.mockClear();
+  onStateRender.mockClear();
 
   store.set(value$, { count: 2 });
   await delay(0);
 
-  expect(onRender).not.toHaveBeenCalled();
+  expect(onLoadableRender).toHaveBeenCalledTimes(1);
+  expect(onStateRender).not.toHaveBeenCalled();
 });
 
-it('useLoadableState reports loading, data, and error transitions', async () => {
+it('useLoadableState commits once for each async state transition', async () => {
   const first = makeDefered<number>();
   const async$ = state(first.promise);
+  const onRender = vi.fn();
   const store = createStore();
 
   function App() {
@@ -97,48 +109,25 @@ it('useLoadableState reports loading, data, and error transitions', async () => 
 
   render(
     <StoreProvider value={store}>
-      <App />
-    </StoreProvider>,
-  );
-
-  expect(screen.getByText('loading')).toBeInTheDocument();
-  first.resolve(1);
-  expect(await screen.findByText('hasData')).toBeInTheDocument();
-
-  const second = makeDefered<number>();
-  store.set(async$, second.promise);
-  expect(await screen.findByText('loading')).toBeInTheDocument();
-  second.reject(new Error('failed'));
-  expect(await screen.findByText('hasError')).toBeInTheDocument();
-});
-
-it('useLastLoadableState stays stable while refetching resolved data', async () => {
-  const async$ = state(Promise.resolve(1));
-  const onRender = vi.fn();
-  const store = createStore();
-
-  function App() {
-    return <div>{useLastLoadableState(async$)}</div>;
-  }
-
-  render(
-    <StoreProvider value={store}>
-      <Profiler id="app" onRender={onRender}>
+      <Profiler id="state" onRender={onRender}>
         <App />
       </Profiler>
     </StoreProvider>,
   );
 
+  expect(screen.getByText('loading')).toBeInTheDocument();
+  expect(onRender).toHaveBeenCalledTimes(1);
+  first.resolve(1);
   expect(await screen.findByText('hasData')).toBeInTheDocument();
-  onRender.mockClear();
+  expect(onRender).toHaveBeenCalledTimes(2);
 
-  const deferred = makeDefered<number>();
-  store.set(async$, deferred.promise);
-  await delay(0);
-  deferred.resolve(2);
-  await delay(0);
-
-  expect(onRender).not.toHaveBeenCalled();
+  const second = makeDefered<number>();
+  store.set(async$, second.promise);
+  expect(await screen.findByText('loading')).toBeInTheDocument();
+  expect(onRender).toHaveBeenCalledTimes(3);
+  second.reject(new Error('failed'));
+  expect(await screen.findByText('hasError')).toBeInTheDocument();
+  expect(onRender).toHaveBeenCalledTimes(4);
 });
 
 it('reset promise atom will reset loadable', async () => {
@@ -541,6 +530,40 @@ it('useLastLoadable does not commit when a new promise resolves to the same prim
   await delay(0);
 
   expect(onRender).not.toHaveBeenCalled();
+});
+
+it('useLastLoadable skips commits when equalityFn considers resolved values equal', async () => {
+  const async$ = state(Promise.resolve({ count: 1 }));
+  const onRender = vi.fn();
+  const store = createStore();
+
+  function App() {
+    const loadable = useLastLoadable(async$, {
+      equalityFn: (previous, next) => previous.count === next.count,
+    });
+    const value = loadable.state === 'hasData' ? loadable.data.count : 'loading';
+    return <div>{value}</div>;
+  }
+
+  render(
+    <StoreProvider value={store}>
+      <Profiler id="app" onRender={onRender}>
+        <App />
+      </Profiler>
+    </StoreProvider>,
+  );
+
+  expect(await screen.findByText('1')).toBeInTheDocument();
+  onRender.mockClear();
+
+  store.set(async$, Promise.resolve({ count: 1 }));
+  await delay(0);
+  expect(onRender).not.toHaveBeenCalled();
+
+  store.set(async$, Promise.resolve({ count: 2 }));
+  await delay(0);
+  expect(onRender).toHaveBeenCalledTimes(1);
+  expect(screen.getByText('2')).toBeInTheDocument();
 });
 
 it('use lastLoadable should keep error', async () => {

--- a/packages/react/src/__tests__/loadable.test.tsx
+++ b/packages/react/src/__tests__/loadable.test.tsx
@@ -7,7 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, test, vi } from 'vitest';
 import { computed, createStore, state } from 'ccstate';
 import type { Computed, State } from 'ccstate';
 import { Profiler, StrictMode, useEffect } from 'react';
-import { StoreProvider, useSet, useLoadable } from '..';
+import { StoreProvider, useSet, useLoadable, useLoadableState, useLastLoadableState } from '..';
 import { delay } from 'signal-timers';
 import { useLastLoadable } from '../useLoadable';
 
@@ -57,6 +57,88 @@ it('convert promise to loadable', async () => {
 
   expect(screen.getByText('loading')).toBeTruthy();
   expect(await screen.findByText('foo')).toBeTruthy();
+});
+
+it('useLoadableState only commits when the loadable state changes', async () => {
+  const value$ = state({ count: 1 });
+  const onRender = vi.fn();
+  const store = createStore();
+
+  function App() {
+    const loadableState = useLoadableState(value$);
+    return <div>{loadableState}</div>;
+  }
+
+  render(
+    <StoreProvider value={store}>
+      <Profiler id="app" onRender={onRender}>
+        <App />
+      </Profiler>
+    </StoreProvider>,
+  );
+
+  expect(await screen.findByText('hasData')).toBeInTheDocument();
+  onRender.mockClear();
+
+  store.set(value$, { count: 2 });
+  await delay(0);
+
+  expect(onRender).not.toHaveBeenCalled();
+});
+
+it('useLoadableState reports loading, data, and error transitions', async () => {
+  const first = makeDefered<number>();
+  const async$ = state(first.promise);
+  const store = createStore();
+
+  function App() {
+    return <div>{useLoadableState(async$)}</div>;
+  }
+
+  render(
+    <StoreProvider value={store}>
+      <App />
+    </StoreProvider>,
+  );
+
+  expect(screen.getByText('loading')).toBeInTheDocument();
+  first.resolve(1);
+  expect(await screen.findByText('hasData')).toBeInTheDocument();
+
+  const second = makeDefered<number>();
+  store.set(async$, second.promise);
+  expect(await screen.findByText('loading')).toBeInTheDocument();
+  second.reject(new Error('failed'));
+  expect(await screen.findByText('hasError')).toBeInTheDocument();
+});
+
+it('useLastLoadableState stays stable while refetching resolved data', async () => {
+  const async$ = state(Promise.resolve(1));
+  const onRender = vi.fn();
+  const store = createStore();
+
+  function App() {
+    return <div>{useLastLoadableState(async$)}</div>;
+  }
+
+  render(
+    <StoreProvider value={store}>
+      <Profiler id="app" onRender={onRender}>
+        <App />
+      </Profiler>
+    </StoreProvider>,
+  );
+
+  expect(await screen.findByText('hasData')).toBeInTheDocument();
+  onRender.mockClear();
+
+  const deferred = makeDefered<number>();
+  store.set(async$, deferred.promise);
+  await delay(0);
+  deferred.resolve(2);
+  await delay(0);
+
+  expect(onRender).not.toHaveBeenCalled();
 });
 
 it('reset promise atom will reset loadable', async () => {

--- a/packages/react/src/__tests__/resolved.test.tsx
+++ b/packages/react/src/__tests__/resolved.test.tsx
@@ -130,6 +130,39 @@ it('useLastResolved does not commit when a new promise resolves to the same prim
   expect(onRender).not.toHaveBeenCalled();
 });
 
+it('useLastResolved skips commits when equalityFn considers resolved values equal', async () => {
+  const async$ = state(Promise.resolve({ count: 1 }));
+  const onRender = vi.fn();
+  const store = createStore();
+
+  function App() {
+    const value = useLastResolved(async$, {
+      equalityFn: (previous, next) => previous.count === next.count,
+    });
+    return <div>{value?.count}</div>;
+  }
+
+  render(
+    <StoreProvider value={store}>
+      <Profiler id="app" onRender={onRender}>
+        <App />
+      </Profiler>
+    </StoreProvider>,
+  );
+
+  expect(await screen.findByText('1')).toBeInTheDocument();
+  onRender.mockClear();
+
+  store.set(async$, Promise.resolve({ count: 1 }));
+  await delay(0);
+  expect(onRender).not.toHaveBeenCalled();
+
+  store.set(async$, Promise.resolve({ count: 2 }));
+  await delay(0);
+  expect(onRender).toHaveBeenCalledTimes(1);
+  expect(screen.getByText('2')).toBeInTheDocument();
+});
+
 it('useResolved accept sync computed', async () => {
   const base$ = state(0);
   function App() {

--- a/packages/react/src/equality.ts
+++ b/packages/react/src/equality.ts
@@ -1,0 +1,9 @@
+export type EqualityFn<T> = (previous: T, next: T) => boolean;
+
+export interface EqualityOptions<T> {
+  equalityFn?: EqualityFn<T>;
+}
+
+export function defaultEqualityFn<T>(previous: T, next: T): boolean {
+  return Object.is(previous, next);
+}

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,7 @@
 export { useGet } from './useGet';
 export { useSet } from './useSet';
 export { useResolved, useLastResolved } from './useResolved';
-export { useLoadable, useLastLoadable } from './useLoadable';
+export { useLoadable, useLastLoadable, useLoadableState, useLastLoadableState } from './useLoadable';
+export type { Loadable, LoadableState } from './useLoadable';
+export type { EqualityFn, EqualityOptions } from './equality';
 export { StoreProvider } from './provider';

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,7 +1,7 @@
 export { useGet } from './useGet';
 export { useSet } from './useSet';
 export { useResolved, useLastResolved } from './useResolved';
-export { useLoadable, useLastLoadable, useLoadableState, useLastLoadableState } from './useLoadable';
+export { useLoadable, useLastLoadable, useLoadableState } from './useLoadable';
 export type { Loadable, LoadableState } from './useLoadable';
 export type { EqualityFn, EqualityOptions } from './equality';
 export { StoreProvider } from './provider';

--- a/packages/react/src/useGet.ts
+++ b/packages/react/src/useGet.ts
@@ -1,10 +1,16 @@
-import { useCallback, useSyncExternalStore } from 'react';
+import { useCallback, useRef, useSyncExternalStore } from 'react';
 import { useStore } from './provider';
+import { defaultEqualityFn, type EqualityOptions } from './equality';
 
 import type { Computed, State } from 'ccstate';
 
-export function useGet<T>(atom: State<T> | Computed<T>) {
+export function useGet<T>(atom: State<T> | Computed<T>, options?: EqualityOptions<T>) {
   const store = useStore();
+  const equalityFn = options?.equalityFn ?? defaultEqualityFn;
+  const snapshotRef = useRef<{
+    atom: State<T> | Computed<T>;
+    value: T;
+  } | null>(null);
   const subscribe = useCallback(
     (fn: () => void) => {
       const controller = new AbortController();
@@ -24,5 +30,15 @@ export function useGet<T>(atom: State<T> | Computed<T>) {
     [store, atom],
   );
 
-  return useSyncExternalStore(subscribe, () => store.get(atom));
+  const getSnapshot = useCallback(() => {
+    const next = store.get(atom);
+    const previous = snapshotRef.current;
+    if (previous !== null && previous.atom === atom && equalityFn(previous.value, next)) {
+      return previous.value;
+    }
+    snapshotRef.current = { atom, value: next };
+    return next;
+  }, [store, atom, equalityFn]);
+
+  return useSyncExternalStore(subscribe, getSnapshot);
 }

--- a/packages/react/src/useLoadable.ts
+++ b/packages/react/src/useLoadable.ts
@@ -1,8 +1,9 @@
 import { useCallback, useRef, useSyncExternalStore } from 'react';
 import { type Computed, type State } from 'ccstate';
 import { useStore } from './provider';
+import { defaultEqualityFn, type EqualityFn, type EqualityOptions } from './equality';
 
-type Loadable<T> =
+export type Loadable<T> =
   | {
       state: 'loading';
     }
@@ -15,25 +16,36 @@ type Loadable<T> =
       error: unknown;
     };
 
-function hasSameData<T>(previous: Loadable<T>, next: Loadable<T>): boolean {
-  return previous.state === 'hasData' && next.state === 'hasData' && previous.data === next.data;
+export type LoadableState = Loadable<unknown>['state'];
+
+function hasSameData<T>(previous: Loadable<T>, next: Loadable<T>, equalityFn: EqualityFn<Awaited<T>>): boolean {
+  return previous.state === 'hasData' && next.state === 'hasData' && equalityFn(previous.data, next.data);
 }
 
-function useLoadableInternal<T, U extends Promise<Awaited<T>> | Awaited<T>>(
-  promise$: State<U> | Computed<U>,
+const selectLoadable = <T>(loadable: Loadable<T>): Loadable<T> => loadable;
+const selectLoadableState = <T>(loadable: Loadable<T>): LoadableState => loadable.state;
+
+function useLoadableInternal<T, R>(
+  promise$: State<Promise<Awaited<T>> | Awaited<T>> | Computed<Promise<Awaited<T>> | Awaited<T>>,
   keepLastResolved: boolean,
-): Loadable<T> {
+  select: (loadable: Loadable<T>) => R,
+  equalityFn: EqualityFn<Awaited<T>>,
+): R {
   const promiseResult = useRef<Loadable<T>>({
     state: 'loading',
   });
+  const selectedResult = useRef(select(promiseResult.current));
 
   const store = useStore();
   const subStore = useCallback(
     (fn: () => void) => {
       function updateResult(result: Loadable<T>, signal: AbortSignal) {
         if (signal.aborted) return;
-        if (keepLastResolved && hasSameData(promiseResult.current, result)) return;
+        if (keepLastResolved && hasSameData(promiseResult.current, result, equalityFn)) return;
         promiseResult.current = result;
+        const nextSelectedResult = select(result);
+        if (Object.is(selectedResult.current, nextSelectedResult)) return;
+        selectedResult.current = nextSelectedResult;
         fn();
       }
 
@@ -92,20 +104,33 @@ function useLoadableInternal<T, U extends Promise<Awaited<T>> | Awaited<T>>(
         controller.abort();
       };
     },
-    [store, promise$],
+    [store, promise$, keepLastResolved, select, equalityFn],
   );
 
-  return useSyncExternalStore(subStore, () => promiseResult.current);
+  return useSyncExternalStore(subStore, () => selectedResult.current);
 }
 
 export function useLoadable<T>(
   atom: State<Promise<Awaited<T>> | Awaited<T>> | Computed<Promise<Awaited<T>> | Awaited<T>>,
 ): Loadable<T> {
-  return useLoadableInternal(atom, false);
+  return useLoadableInternal<T, Loadable<T>>(atom, false, selectLoadable, defaultEqualityFn);
 }
 
 export function useLastLoadable<T>(
   atom: State<Promise<Awaited<T>> | Awaited<T>> | Computed<Promise<Awaited<T>> | Awaited<T>>,
+  options?: EqualityOptions<Awaited<T>>,
 ): Loadable<T> {
-  return useLoadableInternal(atom, true);
+  return useLoadableInternal<T, Loadable<T>>(atom, true, selectLoadable, options?.equalityFn ?? defaultEqualityFn);
+}
+
+export function useLoadableState<T>(
+  atom: State<Promise<Awaited<T>> | Awaited<T>> | Computed<Promise<Awaited<T>> | Awaited<T>>,
+): LoadableState {
+  return useLoadableInternal<T, LoadableState>(atom, false, selectLoadableState, defaultEqualityFn);
+}
+
+export function useLastLoadableState<T>(
+  atom: State<Promise<Awaited<T>> | Awaited<T>> | Computed<Promise<Awaited<T>> | Awaited<T>>,
+): LoadableState {
+  return useLoadableInternal<T, LoadableState>(atom, true, selectLoadableState, defaultEqualityFn);
 }

--- a/packages/react/src/useLoadable.ts
+++ b/packages/react/src/useLoadable.ts
@@ -128,9 +128,3 @@ export function useLoadableState<T>(
 ): LoadableState {
   return useLoadableInternal<T, LoadableState>(atom, false, selectLoadableState, defaultEqualityFn);
 }
-
-export function useLastLoadableState<T>(
-  atom: State<Promise<Awaited<T>> | Awaited<T>> | Computed<Promise<Awaited<T>> | Awaited<T>>,
-): LoadableState {
-  return useLoadableInternal<T, LoadableState>(atom, true, selectLoadableState, defaultEqualityFn);
-}

--- a/packages/react/src/useResolved.ts
+++ b/packages/react/src/useResolved.ts
@@ -1,5 +1,6 @@
 import { useLastLoadable, useLoadable } from './useLoadable';
 import type { Computed, State } from 'ccstate';
+import type { EqualityOptions } from './equality';
 
 export function useResolved<T>(
   atom: State<Promise<Awaited<T>> | Awaited<T>> | Computed<Promise<Awaited<T>> | Awaited<T>>,
@@ -10,7 +11,8 @@ export function useResolved<T>(
 
 export function useLastResolved<T>(
   atom: State<Promise<Awaited<T>> | Awaited<T>> | Computed<Promise<Awaited<T>> | Awaited<T>>,
+  options?: EqualityOptions<Awaited<T>>,
 ): Awaited<T> | undefined {
-  const loadable = useLastLoadable<T>(atom);
+  const loadable = useLastLoadable<T>(atom, options);
   return loadable.state === 'hasData' ? loadable.data : undefined;
 }


### PR DESCRIPTION
## Summary

- add optional `equalityFn` support to `useGet`, `useLastResolved`, and `useLastLoadable`, with `Object.is` as the default
- add `useLoadableState` for primitive lifecycle subscriptions
- verify React Profiler commit counts for equality and loadable-state subscriptions
- document the new APIs and add a minor `ccstate-react` changeset

## Testing

- `pnpm lint`
- `pnpm test` (293 tests, 100% coverage)
- `pnpm build`